### PR TITLE
fix: LSP fixes

### DIFF
--- a/KANBAN.md
+++ b/KANBAN.md
@@ -2,26 +2,29 @@
 
 - Boolean ternary should use a conditional for the lefthand side, vs switch ternaries which should be value-based
 - Check for trailing ends, typos, etc.
+- LSP: Would be nice if # triggers autocomplete for unattached blocks
+- Would be nice to have a conditional "set" where you could if and endif a set of beats on a single conditional.
+- Switch it so mutations, calls etc can be just called inline in a block, and can be directly preceeded by a conditional
 
 ## FIXES
 
-- In the treesitter, em dashes read as comments (haven't tested the engine yet) when following insertions
-    > mia: "All right, {mc} -- I'm sorry if I pushed you."
-    > 
-- and and or are reading as keywords even in text
-- Logic beats mess up the treesitter -- choices after that don't show up right.
+- Test logic blocks thoroughly -- something there doesn't feel right.
+- LSP: Adding a new block doesn't immediately make it available to autocomplete.
+    > This seems to be related to whether the block has content. It's possible the parser itself is missing any case where you have a block *not* followed by beats.
+- LSP: ~ doesn't trigger autocomplete
+
+## IMPROVEMENTS
+
+- SKALDER: add the ability to annotate runs in a side file, like a qflist
+- SKALDER: add the ability to jump in at a specific block
+- SKALDER: add testbed support
+- LSP: Add preceding comments to entity IDE descriptions
 
 ## NEXT
 
 
 ## CURRENT
 
-- Ternary Insertions
-- Mutations
-    * [x] Equate
-    * [ ] Add
-    * [ ] Subtract
-    * [x] Flip
 
 ## DOING
 
@@ -32,3 +35,14 @@
     * [ ] Double check state setup on engine
     * [ ] Handle variable declarations
 - Insertions
+- In the treesitter, em dashes read as comments (haven't tested the engine yet) when following insertions
+    > mia: "All right, {mc} -- I'm sorry if I pushed you."
+    > 
+- and and or are reading as keywords even in text
+- Logic beats mess up the treesitter -- choices after that don't show up right.
+- Ternary Insertions
+- Mutations
+    * [x] Equate
+    * [ ] Add
+    * [ ] Subtract
+    * [x] Flip

--- a/KANBAN.md
+++ b/KANBAN.md
@@ -9,9 +9,6 @@
 ## FIXES
 
 - Test logic blocks thoroughly -- something there doesn't feel right.
-- LSP: Adding a new block doesn't immediately make it available to autocomplete.
-    > This seems to be related to whether the block has content. It's possible the parser itself is missing any case where you have a block *not* followed by beats.
-- LSP: ~ doesn't trigger autocomplete
 
 ## IMPROVEMENTS
 
@@ -46,3 +43,6 @@
     * [ ] Add
     * [ ] Subtract
     * [x] Flip
+- LSP: Adding a new block doesn't immediately make it available to autocomplete.
+    > This seems to be related to whether the block has content. It's possible the parser itself is missing any case where you have a block *not* followed by beats.
+- LSP: ~ doesn't trigger autocomplete

--- a/include/skald.h
+++ b/include/skald.h
@@ -10,7 +10,7 @@
 
 namespace Skald {
 
-enum SkaldLogLevel { VERBOSE, NORMAL, SPARSE };
+enum SkaldLogLevel { VERBOSE, NORMAL, SPARSE, OFF };
 inline static SkaldLogLevel log_level = SkaldLogLevel::NORMAL;
 
 struct LineEntity {

--- a/lsp/README.md
+++ b/lsp/README.md
@@ -82,7 +82,6 @@ NOTE: Don't send raw JSON, because the transport layer expects `Content-Length` 
 
 ## Capabilities
 
-| Feature | Trigger |
 - **Diagnostics**: Syntax errors, undefined block tags (`-> missing`), unused variables.
 - **Go to Definition**: Jumps from `-> tag` to `#tag`, from variable references to `~ var = ...` declarations, from `GO file.ska` to that file. 
 - **Find References**: Shows all occurrences of a block tag, variable, or method.

--- a/lsp/README.md
+++ b/lsp/README.md
@@ -93,6 +93,12 @@ NOTE: Don't send raw JSON, because the transport layer expects `Content-Length` 
 
 ## Architecture
 
+- Everything comes into `main.cpp` ...
+- ... which starts up a Server (`server.h/cpp`).
+- The key processing area is `lsp_actions.h`.
+- This parses into `LspParseState` (`lsp_parse_state.h`) which tracks symbols and their locations.
+- The analyzer in `analyzer.h/cpp` sets up autocompletion etc.
+
 The LSP reuses the Skald engine's PEGTL grammar (`skald_grammar.h`), parse actions (`skald_actions.h`), parse state (`parse_state.h`), and AST types (`skald.h`) by linking against `skald_static`. The key extension point is `lsp_action<Rule>`, which inherits from the base `action<Rule>` so all AST-building logic runs unchanged, then layers symbol-position tracking on top.
 
 Parsing uses `pegtl::memory_input` (string buffers from the editor) instead of `pegtl::file_input`. The full file is re-parsed on every keystroke -- Skald files are small and PEGTL is fast.

--- a/lsp/src/analyzer.cpp
+++ b/lsp/src/analyzer.cpp
@@ -76,9 +76,18 @@ CompletionContext detect_completion_context(const std::string &line_text,
             return CompletionContext::Method;
     }
 
-    // After "~ " or in conditional/injection context: variable completion
-    if (before.size() >= 2 && before.substr(0, 2) == "~ ") {
-        return CompletionContext::Variable;
+    // After "~ ": variable completion (both declarations and mutations)
+    {
+        auto tilde_pos = trimmed.rfind("~ ");
+        if (tilde_pos != std::string::npos) {
+            auto after_tilde = trimmed.substr(tilde_pos + 2);
+            // Only if we're typing the variable name (all identifier chars so far)
+            bool all_id = true;
+            for (char c : after_tilde) {
+                if (!std::isalnum(c) && c != '_') { all_id = false; break; }
+            }
+            if (all_id) return CompletionContext::Variable;
+        }
     }
     // Inside (? ...) conditional
     if (before.find("(? ") != std::string::npos ||

--- a/lsp/src/document.cpp
+++ b/lsp/src/document.cpp
@@ -60,6 +60,18 @@ void Document::parse() {
         module_ = std::move(state.module);
     }
 
+    // Report skipped lines as warnings
+    for (auto &skip : state.skipped_lines) {
+        LspTypes::Diagnostic diag;
+        diag.range.start.line = skip.line;
+        diag.range.start.character = skip.col;
+        diag.range.end.line = skip.line;
+        diag.range.end.character = skip.end_col;
+        diag.severity = LspTypes::DiagnosticSeverity::Warning;
+        diag.message = "Line could not be parsed and was skipped";
+        diagnostics_.push_back(diag);
+    }
+
     run_semantic_checks();
 }
 

--- a/lsp/src/lsp_parse_state.h
+++ b/lsp/src/lsp_parse_state.h
@@ -25,6 +25,8 @@ struct LspParseState : public Skald::ParseState {
     std::vector<SymbolOccurrence> symbols;
     SourceRange last_identifier_range;
     SourceRange mutate_target_range;  // Saved by op_mutate_start for mutation actions
+    std::string mutate_target_name;   // Saved by op_mutate_start to avoid rvalue corruption
+    std::vector<SourceRange> skipped_lines;  // Lines skipped during error recovery
 
     LspParseState(const std::string &filename) : ParseState(filename) {}
 

--- a/lsp/src/main.cpp
+++ b/lsp/src/main.cpp
@@ -3,20 +3,20 @@
 #include "transport.h"
 
 int main() {
-    // Disable debug output from skald library
-    Skald::log_level = Skald::SkaldLogLevel::SPARSE;
-    dbg_out_on = false;
+  // Disable debug output from skald library
+  Skald::log_level = Skald::SkaldLogLevel::OFF;
+  dbg_out_on = false;
 
-    SkaldLsp::Server server;
+  SkaldLsp::Server server;
 
-    while (!server.should_exit()) {
-        auto msg = Transport::read_message();
-        if (!msg) {
-            // stdin closed or read error
-            break;
-        }
-        server.handle_message(*msg);
+  while (!server.should_exit()) {
+    auto msg = Transport::read_message();
+    if (!msg) {
+      // stdin closed or read error
+      break;
     }
+    server.handle_message(*msg);
+  }
 
-    return 0;
+  return 0;
 }

--- a/src/logger.h
+++ b/src/logger.h
@@ -8,7 +8,8 @@
 class Log {
 public:
   template <typename... Args> static void out(Args &&...args) {
-    if (Skald::log_level == Skald::SkaldLogLevel::SPARSE)
+    if (Skald::log_level == Skald::SkaldLogLevel::SPARSE ||
+        Skald::log_level == Skald::SkaldLogLevel::OFF)
       return;
     std::ostringstream stream;
     print_with_spaces(stream, std::forward<Args>(args)...);
@@ -24,6 +25,8 @@ public:
   }
 
   template <typename... Args> static void err(Args &&...args) {
+    if (Skald::log_level == Skald::SkaldLogLevel::OFF)
+      return;
     std::ostringstream stream;
     print_with_spaces(stream, std::forward<Args>(args)...);
     std::cerr << stream.str();

--- a/src/skald_grammar.h
+++ b/src/skald_grammar.h
@@ -209,7 +209,7 @@ struct choice_block : plus<choice_clause> {};
 // SECTION: BEATS
 //
 struct block_tag_name : identifier {};
-struct block_tag_line : seq<one<'#'>, block_tag_name, eol> {};
+struct block_tag_line : seq<one<'#'>, block_tag_name, ws, opt<end_line_comment>, eol> {};
 
 struct logic_beat_else : paren<keyword<'e', 'l', 's', 'e'>> {};
 struct logic_beat_conditional : sor<conditional, logic_beat_else> {};
@@ -235,8 +235,12 @@ struct beat_clause
 
 // SECTION: BLOCKS
 
+// Error recovery: skip any line that doesn't match known block content.
+// This prevents a single bad line from killing the parse for the rest of the file.
+struct skip_line : seq<not_at<block_tag_line>, not_at<seq<ws, eol>>, until<eol>> {};
+
 struct block : seq<block_tag_line, star<sor<ignored, logic_beat_single,
-                                            logic_beat_clause, beat_clause>>> {
+                                            logic_beat_clause, beat_clause, skip_line>>> {
 };
 
 // SECTION: FULL GRAMMAR


### PR DESCRIPTION
- Fixes autocomplete of variable names after ~
- Fixes detection of all block symbols